### PR TITLE
Task35 历史状态快照合约

### DIFF
--- a/contracts/history_snapshot/HistorySnapshotV2.sol
+++ b/contracts/history_snapshot/HistorySnapshotV2.sol
@@ -170,7 +170,7 @@ contract HistorySnapshotV2{
     }
 
     /**
-     * @dev 获取bytes类型的所有历史快照
+     * @dev 获取bytes类型的所有历史快照节点
      * @param _field 存储字段
      * @return blockNumbers 获取到的历史快照
      * @return values 获取到的历史快照对应的值
@@ -185,7 +185,7 @@ contract HistorySnapshotV2{
     }
 
     /**
-     * @dev 获取bytes32类型的所有历史快照
+     * @dev 获取bytes32类型的所有历史快照节点
      * @param _field 存储字段
      * @return blockNumbers 获取到的历史快照
      * @return values 获取到的历史快照对应的值
@@ -199,7 +199,7 @@ contract HistorySnapshotV2{
         }   
     }
     /**
-     * @dev 获取bytes类型的所有历史快照
+     * @dev 获取string类型的所有历史快照节点
      * @param _field 存储字段
      * @return blockNumbers 获取到的历史快照
      * @return values 获取到的历史快照对应的值
@@ -213,7 +213,7 @@ contract HistorySnapshotV2{
         }   
     }
     /**
-     * @dev 获取bytes类型的所有历史快照
+     * @dev 获取uint256类型的所有历史快照节点
      * @param _field 存储字段
      * @return blockNumbers 获取到的历史快照
      * @return values 获取到的历史快照对应的值
@@ -227,7 +227,7 @@ contract HistorySnapshotV2{
         }   
     }
     /**
-     * @dev 获取bytes类型的所有历史快照
+     * @dev 获取address类型的所有历史快照节点
      * @param _field 存储字段
      * @return blockNumbers 获取到的历史快照
      * @return values 获取到的历史快照对应的值
@@ -241,7 +241,7 @@ contract HistorySnapshotV2{
         }   
     }
     /**
-     * @dev 获取bytes类型的所有历史快照
+     * @dev 获取bool类型的所有历史快照节点
      * @param _field 存储字段
      * @return blockNumbers 获取到的历史快照
      * @return values 获取到的历史快照对应的值

--- a/contracts/history_snapshot/HistorySnapshotV2.sol
+++ b/contracts/history_snapshot/HistorySnapshotV2.sol
@@ -4,6 +4,7 @@ pragma experimental ABIEncoderV2;
 
 /**
  * @dev 历史状态快照合约：通过块高来查询某一个值任何历史状态
+ * @author ashinnotfound
  */
 contract HistorySnapshotV2{
 

--- a/contracts/history_snapshot/HistorySnapshotV2.sol
+++ b/contracts/history_snapshot/HistorySnapshotV2.sol
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.4.25;
+pragma experimental ABIEncoderV2;
+
+/**
+ * @dev 历史状态快照合约：通过块高来查询某一个值任何历史状态
+ */
+contract HistorySnapshotV2{
+
+    constructor() public {
+       isAvailable[msg.sender] = true; 
+    }
+    // 权限mapping
+    mapping(address => bool) isAvailable;
+    // 控制权限访问修饰符
+    modifier valid(){
+        require(isAvailable[msg.sender], "HistorySnapshotV2::operate failed: No right");
+        _;
+    }
+    // 添加授权事件
+    event LogAddAvailable(address addr, address operator);
+    // 删除授权事件
+    event LogDelelteAvailable(address addr, address operator);
+    /**
+     * @dev 添加授权
+     * @param _addr 目标用户
+     */
+    function addAvailable(address _addr) public valid {
+        isAvailable[_addr] = true;
+        emit LogAddAvailable(_addr, msg.sender);
+    }
+    /**
+     * @dev 删除授权
+     * @param _addr 目标用户
+     */
+    function deleteAvailable(address _addr) public valid {
+        isAvailable[_addr] = false;
+        emit LogDelelteAvailable(_addr, msg.sender);
+    }
+
+
+    // 历史状态map 字段名=>块号=>数据
+    mapping(string => mapping(uint256 => bytes)) private historyMap;
+    // 块号数组map 字段名=>记录的块号
+    mapping(string => uint256[]) private blockArrayMap;
+
+    // 更新历史状态快照事件 (字段，类型，值(bytes)，操作者, 块号)
+    event LogUpdateHistorySnapshot(string field, string valueType, bytes value, address operator, uint256 blockNumber);
+
+    /**
+     * @dev 增加bytes类型的历史快照
+     * @param _field 存储字段
+     * @param _value 存储的值
+     */
+    function updateBytes(string memory _field, bytes memory _value) public valid {
+        historyMap[_field][block.number] = _value;
+        blockArrayMap[_field].push(block.number);
+
+        emit LogUpdateHistorySnapshot(_field, "bytes", historyMap[_field][block.number], msg.sender, block.number);
+    }
+    /**
+     * @dev 增加bytes32类型的历史快照
+     * @param _field 存储字段
+     * @param _value 存储的值
+     */
+    function updateBytes32(string memory _field, bytes32 _value) public valid {
+        historyMap[_field][block.number] = abi.encode(_value);
+        blockArrayMap[_field].push(block.number);
+
+        emit LogUpdateHistorySnapshot(_field, "bytes32", historyMap[_field][block.number], msg.sender, block.number);
+    }
+    /**
+     * @dev 增加string类型的历史快照
+     * @param _field 存储字段
+     * @param _value 存储的值
+     */
+    function updateString(string memory _field, string memory _value) public valid {
+        historyMap[_field][block.number] = abi.encode(_value);
+        blockArrayMap[_field].push(block.number);
+        
+        emit LogUpdateHistorySnapshot(_field, "string", historyMap[_field][block.number], msg.sender, block.number);
+    }
+    /**
+     * @dev 增加uint256类型的历史快照
+     * @param _field 存储字段
+     * @param _value 存储的值
+     */
+    function updateUint256(string memory _field, uint256 _value) public valid {
+        historyMap[_field][block.number] = abi.encode(_value);
+        blockArrayMap[_field].push(block.number);
+        
+        emit LogUpdateHistorySnapshot(_field, "uint256", historyMap[_field][block.number], msg.sender, block.number);
+    }
+    /**
+     * @dev 增加address类型的历史快照
+     * @param _field 存储字段
+     * @param _value 存储的值
+     */
+    function updateAddress(string memory _field, address _value) public valid {
+        historyMap[_field][block.number] = abi.encode(_value);
+        blockArrayMap[_field].push(block.number);
+        
+        emit LogUpdateHistorySnapshot(_field, "address", historyMap[_field][block.number], msg.sender, block.number);
+    }
+    /**
+     * @dev 增加bool类型的历史快照
+     * @param _field 存储字段
+     * @param _value 存储的值
+     */
+    function updateBool(string memory _field, bool _value) public valid {
+        historyMap[_field][block.number] = abi.encode(_value);
+        blockArrayMap[_field].push(block.number);
+        
+        emit LogUpdateHistorySnapshot(_field, "bool", historyMap[_field][block.number], msg.sender, block.number);
+    }
+
+    /**
+     * @dev 获取bytes类型的历史快照
+     * @param _field 存储字段
+     * @param _blockNumber 块号(如果为0则获取最新值)
+     * @return 获取到的历史快照
+     */
+    function getBytes(string memory _field, uint256 _blockNumber) public view returns (bytes memory){
+        return historyMap[_field][blockArrayMap[_field][getIndex(_blockNumber, blockArrayMap[_field])]];
+    }
+    /**
+     * @dev 获取bytes32类型的历史快照
+     * @param _field 存储字段
+     * @param _blockNumber 块号(如果为0则获取最新值)
+     * @return 获取到的历史快照
+     */
+    function getBytes32(string memory _field, uint256 _blockNumber) public view returns (bytes32){
+        return abi.decode(historyMap[_field][blockArrayMap[_field][getIndex(_blockNumber, blockArrayMap[_field])]], (bytes32));
+    }
+    /**
+     * @dev 获取string类型的历史快照
+     * @param _field 存储字段
+     * @param _blockNumber 块号(如果为0则获取最新值)
+     * @return 获取到的历史快照
+     */
+    function getString(string memory _field, uint256 _blockNumber) public view returns (string memory){
+        return abi.decode(historyMap[_field][blockArrayMap[_field][getIndex(_blockNumber, blockArrayMap[_field])]], (string));
+    }
+    /**
+     * @dev 获取uint256类型的历史快照
+     * @param _field 存储字段
+     * @param _blockNumber 块号(如果为0则获取最新值)
+     * @return 获取到的历史快照
+     */
+    function getUint256(string memory _field, uint256 _blockNumber) public view returns (uint256){
+        return abi.decode(historyMap[_field][blockArrayMap[_field][getIndex(_blockNumber, blockArrayMap[_field])]], (uint256));
+    }
+    /**
+     * @dev 获取address类型的历史快照
+     * @param _field 存储字段
+     * @param _blockNumber 块号(如果为0则获取最新值)
+     * @return 获取到的历史快照
+     */
+    function getAddress(string memory _field, uint256 _blockNumber) public view returns (address){
+        return abi.decode(historyMap[_field][blockArrayMap[_field][getIndex(_blockNumber, blockArrayMap[_field])]], (address));
+    }
+    /**
+     * @dev 获取bool类型的历史快照
+     * @param _field 存储字段
+     * @param _blockNumber 块号(如果为0则获取最新值)
+     * @return 获取到的历史快照
+     */
+    function getBool(string memory _field, uint256 _blockNumber) public view returns (bool){
+        return abi.decode(historyMap[_field][blockArrayMap[_field][getIndex(_blockNumber, blockArrayMap[_field])]], (bool));
+    }
+
+    /**
+     * @dev 获取bytes类型的所有历史快照
+     * @param _field 存储字段
+     * @return blockNumbers 获取到的历史快照
+     * @return values 获取到的历史快照对应的值
+     */
+    function getBytesHistory(string memory _field) public view returns (uint256[] memory blockNumbers, bytes[] memory values){
+        blockNumbers = blockArrayMap[_field];
+        values = new bytes[](blockNumbers.length);
+        
+        for(uint256 i = 0; i < blockNumbers.length; i++){
+            values[i] = historyMap[_field][blockNumbers[i]];
+        }   
+    }
+
+    /**
+     * @dev 获取bytes32类型的所有历史快照
+     * @param _field 存储字段
+     * @return blockNumbers 获取到的历史快照
+     * @return values 获取到的历史快照对应的值
+     */
+    function getBytes32History(string memory _field) public view returns (uint256[] memory blockNumbers, bytes32[] memory values){
+        blockNumbers = blockArrayMap[_field];
+        values = new bytes32[](blockNumbers.length);
+        
+        for(uint256 i = 0; i < blockNumbers.length; i++){
+            values[i] = abi.decode(historyMap[_field][blockNumbers[i]], (bytes32));
+        }   
+    }
+    /**
+     * @dev 获取bytes类型的所有历史快照
+     * @param _field 存储字段
+     * @return blockNumbers 获取到的历史快照
+     * @return values 获取到的历史快照对应的值
+     */
+    function getStringHistory(string memory _field) public view returns (uint256[] memory blockNumbers, string[] memory values){
+        blockNumbers = blockArrayMap[_field];
+        values = new string[](blockNumbers.length);
+
+        for(uint256 i = 0; i < blockNumbers.length; i++){
+            values[i] = abi.decode(historyMap[_field][blockNumbers[i]], (string));
+        }   
+    }
+    /**
+     * @dev 获取bytes类型的所有历史快照
+     * @param _field 存储字段
+     * @return blockNumbers 获取到的历史快照
+     * @return values 获取到的历史快照对应的值
+     */
+    function getUint256History(string memory _field) public view returns (uint256[] memory blockNumbers, uint256[] memory values){
+        blockNumbers = blockArrayMap[_field];
+        values = new uint256[](blockNumbers.length);        
+
+        for(uint256 i = 0; i < blockNumbers.length; i++){
+            values[i] = abi.decode(historyMap[_field][blockNumbers[i]], (uint256));
+        }   
+    }
+    /**
+     * @dev 获取bytes类型的所有历史快照
+     * @param _field 存储字段
+     * @return blockNumbers 获取到的历史快照
+     * @return values 获取到的历史快照对应的值
+     */
+    function getAddressHistory(string memory _field) public view returns (uint256[] memory blockNumbers, address[] memory values){
+        blockNumbers = blockArrayMap[_field];
+        values = new address[](blockNumbers.length);
+        
+        for(uint256 i = 0; i < blockNumbers.length; i++){
+            values[i] = abi.decode(historyMap[_field][blockNumbers[i]], (address));
+        }   
+    }
+    /**
+     * @dev 获取bytes类型的所有历史快照
+     * @param _field 存储字段
+     * @return blockNumbers 获取到的历史快照
+     * @return values 获取到的历史快照对应的值
+     */
+    function getBoolHistory(string memory _field) public view returns (uint256[] memory blockNumbers, bool[] memory values){
+        blockNumbers = blockArrayMap[_field];
+        values = new bool[](blockNumbers.length);
+
+        for(uint256 i = 0; i < blockNumbers.length; i++){
+            values[i] = abi.decode(historyMap[_field][blockNumbers[i]], (bool));
+        }   
+    }
+
+    /**
+     * @dev 辅助方法:二分法获取array中第一个小于_blockNumber的块号下标
+     * @param _blockNumber 要查询的块号(如果为0则获取最新值)
+     * @param array 块号数组
+     * @return result 计算得到的块号下标
+     */
+    function getIndex(uint256 _blockNumber, uint256[] memory array) internal pure returns (uint256 result) {
+        require(array.length != 0, "HistorySnapshotV2::operate failed: Snapshot for this field is empty");
+        if (_blockNumber == 0){
+            return array.length - 1;
+        }
+
+        uint256 left = 0;
+        uint256 right = array.length - 1;
+
+        while (left <= right) {
+            uint256 mid = (left + right) >> 2;
+            if (array[mid] == _blockNumber) {
+                return mid;
+            } else if (array[mid] < _blockNumber) {
+                left = mid + 1;
+            } else {
+                right = mid - 1;
+            }
+        }
+
+        return right;
+    }
+}

--- a/contracts/history_snapshot/HistorySnapshotV2Demo.sol
+++ b/contracts/history_snapshot/HistorySnapshotV2Demo.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.4.25;
+pragma experimental ABIEncoderV2;
+
+import "./HistorySnapshotV2.sol";
+/**
+ * @dev 历史状态快照合约测试demo
+ */
+contract HistorySnapshotV2Demo{
+    HistorySnapshotV2 private historySnapshotV2;
+    
+    //以string类型为例
+    function test() returns (string memory value1, string memory value2, uint256[] memory blockNumbers, string[] memory values){
+        historySnapshotV2 = new HistorySnapshotV2;
+
+        // updateString1();
+        value1 = historySnapshotV2.getString("test", 0);
+        // 此时value1应该为hello
+        // updateString2();
+        value1 = historySnapshotV2.getString("test", 0);
+        // 此时value1应该为world
+        (blockNumbers, values) = historySnapshotV2.getStringHistory("test");
+        // blockNumbers应该为[num1, num2] 其中num1和num2为调用updateString1()、updateString2()时的块号 
+        // values应该为["hello", "world"]
+    }
+
+    function updateString1() public {
+        historySnapshotV2.updateString("test", "hello");
+    }
+    function updateString2() public {
+        historySnapshotV2.updateString("test", "world");
+    }
+}

--- a/docs/history_snapshot/HistorySnapshotV2.md
+++ b/docs/history_snapshot/HistorySnapshotV2.md
@@ -1,0 +1,75 @@
+# HistorySnapshotV2
+
+>   广东工业大学 陈汛
+
+## 合约简介
+
+历史状态快照合约：通过块高来查询某一个值任何历史状态，适用于0.4.25及以上版本。
+
+## 使用方法
+
+import该合约(HistorySnapshotV2.sol)并实例化调用即可。下面是一个例子：
+
+```
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.4.25;
+pragma experimental ABIEncoderV2;
+
+import "./HistorySnapshotV2.sol";
+/**
+ * @dev 历史状态快照合约测试demo
+ */
+contract HistorySnapshotV2Demo{
+    HistorySnapshotV2 private historySnapshotV2;
+    
+    //以string类型为例
+    function test() returns (string memory value1, string memory value2, uint256[] memory blockNumbers, string[] memory values){
+        historySnapshotV2 = new HistorySnapshotV2;
+
+        // updateString1();
+        value1 = historySnapshotV2.getString("test", 0);
+        // 此时value1应该为hello
+        // updateString2();
+        value1 = historySnapshotV2.getString("test", 0);
+        // 此时value1应该为world
+        (blockNumbers, values) = historySnapshotV2.getStringHistory("test");
+        // blockNumbers应该为[num1, num2] 其中num1和num2为调用updateString1()、updateString2()时的块号 
+        // values应该为["hello", "world"]
+    }
+
+    function updateString1() public {
+        historySnapshotV2.updateString("test", "hello");
+    }
+    function updateString2() public {
+        historySnapshotV2.updateString("test", "world");
+    }
+}
+```
+
+
+
+## API列表
+
+| 编号 | API                                                          | 描述                              |
+| ---- | ------------------------------------------------------------ | --------------------------------- |
+| 1    | addAvailable(address _addr) public                           | 添加授权                          |
+| 2    | deleteAvailable(address _addr) public                        | 删除授权                          |
+| 3    | updateBytes(string memory _field, bytes memory _value) public | 增加bytes类型的历史快照           |
+| 4    | updateBytes32(string memory _field, bytes32 _value) public   | 增加bytes32类型的历史快照         |
+| 5    | updateString(string memory _field, string memory _value) public | 增加string类型的历史快照          |
+| 6    | updateUint256(string memory _field, uint256 _value) public   | 增加uint256类型的历史快照         |
+| 7    | updateAddress(string memory _field, address _value) public   | 增加address类型的历史快照         |
+| 8    | updateBool(string memory _field, bool _value) public         | 增加bool类型的历史快照            |
+| 9    | getBytes(string memory _field, uint256 _blockNumber) public view returns (bytes memory) | 获取bytes类型的历史快照           |
+| 10   | getBytes32(string memory _field, uint256 _blockNumber) public view returns (bytes32) | 获取bytes32类型的历史快照         |
+| 11   | getString(string memory _field, uint256 _blockNumber) public view returns (string memory) | 获取string类型的历史快照          |
+| 12   | getUint256(string memory _field, uint256 _blockNumber) public view returns (uint256) | 获取uint256类型的历史快照         |
+| 13   | getAddress(string memory _field, uint256 _blockNumber) public view returns (address) | 获取address类型的历史快照         |
+| 14   | getBool(string memory _field, uint256 _blockNumber) public view returns (bool) | 获取bool类型的历史快照            |
+| 15   | getBytesHistory(string memory _field) public view returns (uint256[] memory blockNumbers, bytes[] memory values) | 获取bytes类型的所有历史快照节点   |
+| 16   | getBytes32History(string memory _field) public view returns (uint256[] memory blockNumbers, bytes32[] memory values) | 获取bytes32类型的所有历史快照节点 |
+| 17   | getStringHistory(string memory _field) public view returns (uint256[] memory blockNumbers, string[] memory values) | 获取string类型的所有历史快照节点  |
+| 18   | getUint256History(string memory _field) public view returns (uint256[] memory blockNumbers, uint256[] memory values) | 获取uint256类型的所有历史快照节点 |
+| 19   | getAddressHistory(string memory _field) public view returns (uint256[] memory blockNumbers, address[] memory values) | 获取address类型的所有历史快照节点 |
+| 20   | getBoolHistory(string memory _field) public view returns (uint256[] memory blockNumbers, bool[] memory values) | 获取bool类型的所有历史快照节点    |
+


### PR DESCRIPTION
Task35 历史状态快照合约
- 适用于0.4.25及以上版本。
- 兼容多种类型。
- 通过块高来查询某一个值任何历史状态
- 查询某一字段的所有历史快照节点